### PR TITLE
feat: update pagination for tags page

### DIFF
--- a/pages/PageNavigation.tsx
+++ b/pages/PageNavigation.tsx
@@ -1,6 +1,7 @@
 import { rangeInclusive } from "../server/utility";
 import Link from "next/link";
 import { PropsWithChildren } from "react";
+import { useRouter } from "next/router";
 
 const PAGE_SPREAD = 2;
 
@@ -24,29 +25,23 @@ const NavigationItem = ({ children }: PropsWithChildren) => {
 };
 
 export const PageNavigation = ({
-  search,
   page,
   pages,
-  limit,
-  pageUrl = "",
+  params,
 }: {
-  search?: string;
   page: number;
-  pageUrl?: string;
   pages: number;
-  limit?: number;
+  params?: { [_name: string]: string };
 }) => {
+  const router = useRouter();
   const start = Math.max(1, page - PAGE_SPREAD);
   const end = Math.min(page + PAGE_SPREAD, pages);
 
   const link = (page: number) => {
-    const searchParams: any = {
+    return `/${router.pathname}?${new URLSearchParams({
       page: page.toString(),
-    };
-    if (limit) searchParams.limit = limit.toString();
-    if (search) searchParams.search = search;
-
-    return `/${pageUrl}?${new URLSearchParams(searchParams)}`;
+      ...(params || {}),
+    })}`;
   };
 
   return (

--- a/pages/PageNavigation.tsx
+++ b/pages/PageNavigation.tsx
@@ -28,21 +28,25 @@ export const PageNavigation = ({
   page,
   pages,
   limit,
+  pageUrl = "",
 }: {
-  search: string;
+  search?: string;
   page: number;
+  pageUrl?: string;
   pages: number;
-  limit: number;
+  limit?: number;
 }) => {
   const start = Math.max(1, page - PAGE_SPREAD);
   const end = Math.min(page + PAGE_SPREAD, pages);
 
   const link = (page: number) => {
-    return `/?${new URLSearchParams({
-      search,
-      limit: limit.toString(),
+    const searchParams: any = {
       page: page.toString(),
-    })}`;
+    };
+    if (limit) searchParams.limit = limit.toString();
+    if (search) searchParams.search = search;
+
+    return `/${pageUrl}?${new URLSearchParams(searchParams)}`;
   };
 
   return (

--- a/pages/index.page.tsx
+++ b/pages/index.page.tsx
@@ -54,10 +54,12 @@ const HomePage: NextPage<PageProps> = ({ search, results, page, limit }) => {
           ))}
         </div>
         <PageNavigation
-          search={search}
           page={page}
           pages={results.pages}
-          limit={limit}
+          params={{
+            limit: limit.toString(),
+            search,
+          }}
         />
       </div>
     </>


### PR DESCRIPTION
The tags page now has  page navigation at the bottom.

Closes #18 